### PR TITLE
arduino.h -> Arduino.h

### DIFF
--- a/GUVA-S12SD.cpp
+++ b/GUVA-S12SD.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "arduino.h"
+#include "Arduino.h"
 #include "GUVA-S12SD.h"
 
 /* https://github.com/Marzogh/Tricorder/blob/master/Tricorder/GUVAS12SD.ino */

--- a/GUVA-S12SD.h
+++ b/GUVA-S12SD.h
@@ -15,7 +15,7 @@
  */
 #ifndef _GUVA_S12SD_h
 #define _GUVA_S12SD_h
-#include "arduino.h"
+#include "Arduino.h"
 
 class GUVAS12SD
 {


### PR DESCRIPTION
Possibly it previously worked on OSes with case-insensitive filenames. Arduino.h is the standard.